### PR TITLE
step4/step5 sms認証画面/お届け先入力マークアップを移植

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "modules/footer.scss";
 @import "step3.scss";
 @import "step4.scss";
+@import "step5.scss";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "modules/header.scss";
 @import "modules/footer.scss";
 @import "step3.scss";
+@import "step4.scss";

--- a/app/assets/stylesheets/step4.scss
+++ b/app/assets/stylesheets/step4.scss
@@ -1,0 +1,25 @@
+.comfirm-title {
+  border-bottom: 1px solid #f5f5f5;
+}
+.confirm-phone-text {
+  margin-top: 10px;
+}
+.form-inner {
+  border-top: 1px solid #f5f5f5;
+}
+.comfirm-btn {
+  margin-bottom: 25px;
+}
+.phone-comfirm-text {
+  font-weight: bold;
+}
+.text-left a{
+  text-decoration: none;
+}
+.text-left a:hover {
+  color: #b3d4fc;
+  text-decoration:underline;
+}
+.text-center {
+  padding-bottom: 20px;
+}

--- a/app/assets/stylesheets/step5.scss
+++ b/app/assets/stylesheets/step5.scss
@@ -1,0 +1,33 @@
+.adress-name {
+  display: inline-block;
+}
+.last-name-kana {
+  display: inline-block;
+}
+.adress-form-require {
+  background-color: gray;
+  margin: 0 0 0 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+}
+#user_deliver_adress_attributes_prefecture {
+  height: 47px;
+  width: 335px;
+  padding: 10px 16px 8px;
+  margin-top: 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  line-height: 1.5;
+  font-size: 16px;
+}
+#adress-form {
+  padding: 40px 40px 64px;
+  border-top: 1px solid #f5f5f5;
+  input:focus {
+    outline: 0;
+    border-color: #0099e8;
+  }
+}

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -1,4 +1,34 @@
-SNSで届いた認証番号を入力してください
-%form{ action: step5_signup_index_path ,method: :get}
-  %input{type: "text"}
-  %input{type: "submit"}
+= render 'signup/shared/header'
+%body.phone-registration-body
+  %main.phone-registration-body__main
+    %section
+      %h2.phone-registration-body__title.comfirm-title 電話番号認証
+      %form#form1{ action: step5_signup_index_path ,method: :get }
+        %input{ name: "__csrf_value", type: "hidden", value: "" }/
+        .phone-content-form
+          .phone-content-form__group
+            %label.phone-content-form__number 認証番号
+            %input.phone-content-form__input-default{ name: "phone-number", placeholder: "認証番号の入力", type: "text", value: "" }/
+            %p.confirm-phone-text
+              SMSで届いた認証番号を入力して下さい
+          .phone-content-form__group
+            %button.phone-content-form__btn-default.comfirm-btn{ type: "submit" } 認証して完了
+      %form#form1.form-inner{ action: "", method: "POST", novalidate: "novalidate" }
+        .phone-content-form.confirm-content
+          .phone-content-form__group
+            %label.phone-content-form__number 30秒経っても認証番号が届かない方へ
+            %p.phone-text 電話で認証番号を聞くこともできます。
+          .phone-content-form__group
+            %button.phone-content-form__btn-default{ type: "submit" } 電話で認証番号を聞く（通話無料）
+          .phone-content-form__group
+            %p.phone-comfirm-text
+              認証番号を再送することもできます。もう一度電話番号を入力して下さい。
+          .phone-content-form__group.text-left
+            %p
+              %a{ href: "#", target: "_blank" }
+                電話を番号再度入力する
+            %p.text-center
+              ※SMSが届かない場合は
+              %a{ href: "#", target: "_blank" }> SMS受信設定
+              を確認して、もう一度電話番号を入力して下さい。
+= render 'signup/shared/footer'

--- a/app/views/signup/step5.html.haml
+++ b/app/views/signup/step5.html.haml
@@ -1,43 +1,47 @@
-= form_for @user, url: signup_index_path, method: :post, html: {class: 'forth-main-wrapper__box'} do |f|
-  = f.fields_for :deliver_adress do |d|
-    .field
-      = f.label :名字
-      %br/
-      = d.text_field :family_name, placeholder: '例) めるかり'
-    .field
-      = f.label :名前
-      %br/
-    = d.text_field :first_name, placeholder: '例) 太郎'
-    .field
-      = f.label :名字のカナ
-      %br/
-    = d.text_field :family_name_kana, placeholder: '例) メルカリ'
-    .field
-      = f.label :名前のカナ
-      %br/
-    = d.text_field :first_name_kana, placeholder: '例) タロウ'
-    .field
-      = f.label :郵便番号
-      %br/
-    = d.text_field :zip_code
-    .field
-      = f.label :都道府県
-      %br/
-    = d.text_field :prefecture
-    .field
-      = f.label :市区町村
-      %br/
-    = d.text_field :city
-    .field
-      = f.label :番地
-      %br/
-    = d.text_field :adress1
-    .field
-      = f.label :建物名
-      %br/
-    = d.text_field :adress2
-    .field
-      = f.label :電話番号
-      %br/
-    = d.text_field :telephone
-    = f.submit "Sign up"
+= render 'signup/shared/header'
+%body.new-member-registration-body
+  %main.new-member-registration-body__main
+    %section
+      .new-member-registration__title 発送元・お届け先入力
+      = form_for @user, url: signup_index_path, method: :post, html: { class: 'registration-form' } do |f|
+        = f.fields_for :deliver_adress do |d|
+          .new-member-registration-form-content
+            .new-member-registration-form-content__group
+              = f.label :お名前, { class: 'new-registration-label adress-name' }
+              = f.label :必須, { class: 'form-require' }
+              = d.text_field :family_name, placeholder: '例) 安藤', class:"input-default"
+              = d.text_field :first_name, placeholder: '例) 拓也', class:"input-default"
+            .new-member-registration-form-content__group
+              = f.label :お名前カナ, { class: 'new-registration-label adress-name' }
+              = f.label :必須, { class: 'form-require' }
+              = d.text_field :family_name_kana, placeholder: '例) アンドウ', class: "input-default last-name-kana"
+              = d.text_field :first_name_kana, placeholder: '例) タクヤ', class: "input-default"
+            .new-member-registration-form-content__group
+              = f.label :郵便番号, { class: 'new-registration-label' }
+              = f.label :必須, { class: 'form-require' }
+              = d.text_field :zip_code, placeholder: '例）1234567', class: "input-default"
+            .new-member-registration-form-content__group
+              = f.label :都道府県, { class: 'new-registration-label' }
+              = f.label :必須, { class: 'form-require' }
+              .prefecture-select-wrap
+                .adress-select-wrap
+                  = d.collection_select :prefecture, Prefecture.all, :id, :name, class: "select-prefecture"
+            .new-member-registration-form-content__group
+              = f.label :市区町村, { class: 'new-registration-label' }
+              = f.label :必須, { class: 'form-require' }
+              = d.text_field :city, placeholder: '例）横浜市緑区', class: "input-default"
+            .new-member-registration-form-content__group
+              = f.label :番地, { class: 'new-registration-label' }
+              = f.label :必須, { class: 'form-require' }
+              = d.text_field :adress1, placeholder: "例）青山1-1-1", class: "input-default"
+            .new-member-registration-form-content__group
+              = f.label :建物名, { class: 'new-registration-label' }
+              = f.label :任意, { class: 'adress-form-require' }
+              = d.text_field :adress2, placeholder: "例）柳ビル103", class: "input-default"
+            .new-member-registration-form-content__group
+              = f.label :電話番号, { class: 'new-registration-label' }
+              = f.label :任意, { class: 'adress-form-require' }
+              = d.text_field :telephone, placeholder: "例）09012345678", class: "input-default"
+            .new-member-registration-form-content__group
+              = f.submit "次に進む", class:"btn-default btn-red"
+= render 'signup/shared/footer'


### PR DESCRIPTION
## WHAT
ユーザー新規登録画面のsms認証画面とお届け先入力マークアップ

## WHY
ユーザーがサービスを利用する為に登録してもらう情報をデータベースに保存する為

## 画像
https://gyazo.com/f10485b698637e4b8c84a4fba8231625
https://gyazo.com/b449cea8ea399e197a0052a6d1ef5653
https://gyazo.com/33e1b9aa9cd65ad9ba4c9a5a5575bed8