### PR TITLE
商品一覧と商品詳細機能の作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,5 +303,4 @@ Association
 
 ## ER図
 
-![ER図](https://imgur.com/a/O1PBNDZ)
-
+[![ER図](https://imgur.com/a/O1PBNDZ)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@
 @import "modules/signin.scss";
 @import "modules/header.scss";
 @import "modules/footer.scss";
+@import './modules/item/*';
 @import "p-form-footer.scss";
 @import "p-form-header.scss";
 @import "sell.scss"
-

--- a/app/assets/stylesheets/modules/item/show.scss
+++ b/app/assets/stylesheets/modules/item/show.scss
@@ -1,0 +1,581 @@
+.clearfix::after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.item-box-container {
+  background: #fff;
+  margin: 40px auto 0;
+  padding: 24px 40px 40px;
+}
+
+.l-single-container {
+  width: 700px;
+  box-sizing: border-box;
+}
+
+.item-name {
+  font-size: 24px;
+  text-align: center;
+  word-wrap: break-word;
+  line-height: 1.4;
+  font-weight: bold;
+}
+
+.item-main-content {
+  margin: 16px 0 0;
+}
+
+.item-photo {
+  float: left;
+  min-width: 300px;
+  max-width: 300px;
+  min-height: 375px;
+}
+
+.owl-carousel {
+  position: relative;
+}
+
+.owl-carousel .owl-stage-outer {
+  position: relative;
+  overflow: hidden;
+}
+
+.owl-carousel .owl-stage {
+  position: relative;
+}
+
+.owl-carousel .owl-item-inner {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding: 0 0 100%;
+}
+
+.owl-carousel img {
+  width: 100%;
+  vertical-align: bottom;
+}
+
+.owl-carousel .owl-nav {
+  display: none;
+}
+
+.owl-item-java {
+  display: none;
+}
+
+.owl-dots {
+  line-height: 0;
+}
+
+.owl-dot {
+  width: 60px;
+  height: 60px;
+  max-height: none;
+// 上は幅広画面用のscss
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  opacity: 0.5;
+}
+
+.owl-dot.active {
+  opacity: 1;
+  cursor: default;
+}
+
+// .active {
+//   opacity: 10;
+// }
+
+.owl-dot span {
+  display: none;
+}
+
+.owl-dot-inner {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  // 上は幅広画面用のscss
+}
+
+.item-detail-table {
+  float: right;
+  max-width: 300px;
+  height: 420px;
+  margin: 0 auto;
+    // 上は幅広画面用のscss
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #f5f5f5;
+}
+
+.item-detail-table th {
+  padding: 8px;
+    // 上は幅広画面用のscss
+  width: 39%;
+  text-align: left;
+  font-weight: 400;
+  background: #fafafa;
+  border-collapse: collapse;
+  border: 1px solid #f5f5f5;
+}
+
+.item-detail-table td {
+  padding: 8px;
+    // 上は幅広画面用のscss
+  width: 61%;
+  background: #fff;
+}
+
+.item-detail-table a:first-child {
+  margin: 0;
+}
+
+.fa.fa-smile {
+  color:#ef5185;
+}
+
+.fa.fa-meh {
+  color: #fba933;
+}
+
+.fa.fa-frown {
+  color: #6ab5d8;
+}
+
+.item-user-ratings {
+  display: inline-block;
+  margin: 8px 0 0 16px;
+}
+
+.item-user-ratings:first-child {
+  margin: 0;
+}
+
+.item-user-ratings span {
+  vertical-align: middle;
+}
+
+.item-user-ratings i {
+  font-size: 16px;
+  vertical-align: middle;
+}
+
+.item-price-box {
+  margin: 24px 0 0;
+  // width: 100vw;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.item-price {
+  margin: 0 16px 0 0;
+  font-size: 50px;
+    // 上は幅広画面用のscss
+}
+
+.item-tax {
+  font-size: 10px;
+}
+
+.item-shipping-fee {
+  display: inline-block;
+  font-size: 16px;
+}
+
+.item-buy-btn {
+  font-size: 24px;
+  line-height: 60px;
+   // 上は幅広画面用のscss
+  display: block;
+  margin-top: 16px;
+  background: #ea352d;
+  // font-size: 14px;
+  color: #fff;
+  // line-height: 56px;
+  text-align: center;
+  font-weight: 600;
+  -webkit-transition: all ease-out .3s;
+  transition: all ease-out .3s;
+  // width: 100vw;
+}
+
+.item-description {
+  padding: 32px 0 0;
+  font-size: 18px;
+     // 上は幅広画面用のscss
+  // padding: 24px 0 0;
+  line-height: 1.5;
+}
+
+.item-description-inner {
+  white-space: pre-wrap;
+}
+
+.item-button-container {
+  margin: 16px 0 0;
+  font-size: 0;
+}
+
+.item-button-left {
+  float: left;
+     // 上は幅広画面用のscss
+}
+
+.item-button {
+  display: inline-block;
+  padding: 8px 16px;
+  border-radius: 40px;
+  -webkit-transition: all ease-out .3s;
+  transition: all ease-out .3s;
+}
+
+.item-button-like.is-liked {
+  border: 1px solid #ea352d;
+  background: none;
+  color: #ea352d;
+}
+
+.item-button-container span {
+  font-size: 14px;
+   // 上は幅広画面用のscss
+  display: inline-block;
+  margin: 1px 0 0 8px;
+  // font-size: 12px;
+  vertical-align: middle;
+}
+
+.item-button-report {
+  margin: 0 0 0 16px;
+    // 上は幅広画面用のscss
+  // margin: 0 0 0 8px;
+  color: #333;
+  background: #f5f5f5;
+}
+
+.item-button-right {
+  margin: 8px 0 0;
+  float: right;
+      // 上は幅広画面用のscss
+}
+
+.item-button-right span {
+  color:  #0099e8;
+}
+
+.item-button-container i {
+  font-size: 14px;
+  vertical-align: middle;
+}
+
+.item-detail-message {
+  width: 700px;
+    // 上は幅広画面用のscss
+    // width: 100vw;
+  margin: 8px auto;
+}
+
+.message-container {
+  // width: 100vw;
+}
+
+.message-content {
+  padding: 24px;
+     // 上は幅広画面用のscss
+  // padding: 24px 7.5%;
+  background: #fff;
+}
+
+.message-form p {
+  padding: 8px;
+  font-size: 14px;
+  background: #fff6de;
+}
+
+.message-form .textarea-default {
+  margin: 8px 0 0;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  min-height: 104px;
+  padding: 10px 0;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
+.message-submit {
+  width: 100%;
+  margin: 8px 0 0;
+  font-size: 0;
+  text-align: center;
+}
+
+.btn-gray {
+  background: #aaa;
+  border: 1px solid #aaa;
+  color: #fff;
+}
+
+.btn-default {
+  display: block;
+  width: 100%;
+  line-height: 48px;
+  font-size: 14px;
+  border: 1px solid transparent;
+  -webkit-transition: all ease-out .3s;
+  transition: all ease-out .3s;
+  cursor: pointer;
+  text-align: center;
+}
+
+.nav-item-link-prev-next {
+  margin: 24px auto 0;
+  // width: 700px;
+  list-style-type: none;
+  width: 100vw;
+  display: flex;
+  // width: 45%;
+  padding: 0;
+}
+
+.nav-item-link-prev {
+  position: relative;
+  padding-left: 5px;
+}
+
+// .nav-item-link-prev-next li, .nav-user-link-prev-next li {
+//   width: 45%;
+//    上は幅広画面用のscss
+//   position: relative;
+//   width: 43%;
+//   word-wrap: break-word;
+// }
+
+.nav-item-link-prev-next li {
+  width: 45%
+}
+
+.nav-item-link-prev-next li:first-child {
+  margin-right: 60px;
+  margin-left: 20px;
+}
+.nav-item-link-next {
+  text-align: right;
+  position: relative;
+}
+
+.fa.fa-angle-left {
+  font-size: 25px;
+  position: absolute;
+  top: -6px;
+  left: -7px;
+}
+
+.fa.fa-angle-right {
+  font-size: 25px;
+  position: absolute;
+  bottom: -5px;
+  right: -13px;
+}
+
+.item-social-media-box {
+  margin: 24px auto;
+  padding: 32px 0 24px;
+  // width: 700px;
+   // 上は幅広画面用のscss
+   width: 100vw;
+  background: #fff;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.social-media-box {
+  margin: 16px 0 0;
+  text-align: center;
+  font-size: 0;
+  list-style: none;
+}
+
+.social-media-box li {
+  display: inline-block;
+  margin: 0 8px 8px 0;
+  vertical-align: middle;
+  text-align: center;
+}
+
+.social-media-box i {
+  font-size: 44px;
+  width: 44px;
+  height: 44px;
+  border-radius: 4px;
+  line-height: 44px;
+}
+
+.social-media-box li a {
+  background: #385185!important;
+}
+
+// .social-media-box a:first-child {
+//   background: #385185;
+// }
+
+// .share-btn {
+//   background: #385185;
+// }
+.fa-facebook-square {
+  color: #fff;
+  background: #385185;
+  font-size: 18px;
+}
+
+.fa-twitter-square {
+  color: #fff;
+  background: #5d9dc9;
+  font-size: 24px;
+}
+
+.fab.fa-line {
+  color: #fff;
+  background: #00c137;
+  font-size: 22px;
+}
+
+.fa-pinterest-square {
+  color: #fff;
+  background: #aa262a;
+  font-size: 18px;
+}
+
+// @media screen and (min-width: 1068px) {
+//   .fab.fa-line {
+//     display: none;
+//   }
+// }
+
+@media screen and (min-width: 769px) {
+  .social-media-box li.social-hidden-item {
+      display: none;
+  }
+
+  .item-btn-float-area {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .item-box-container {
+      // padding: 24px 40px 40px;
+    background: #fff;
+    margin: 40px auto 0;
+    padding: 24px 16px 55px 16px;
+  }
+  .l-single-container {
+    // width: 700px;
+    width: 100vw;
+    margin: 0 auto;
+  }
+  .item-photo {
+    float: none;
+    margin: 0 auto;
+  }
+
+//   .owl-carousel .owl-item-inner {
+//     position: relative;
+//     width: 100%;
+//     height: 0;
+//     padding: 0 0 100%;
+// }
+  .item-detail-table {
+    width: 100%;
+    max-width: 360px;
+    margin: 8px auto 0;
+    border-collapse: collapse;
+    border: 1px solid #f5f5f5;
+    float: none;
+  }
+
+  .item-price {
+    margin: 0 8px 0 0;
+    font-size: 32px;
+  }
+
+  // .item-description p{
+  //   font-size: smaller;
+  // }
+
+  .item-description-inner {
+    // border-style: solid;
+    font-size: smaller;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  // .item-description-inner p {
+  //   font-size: smaller;
+  // }
+
+  // .item-shipping-fee {
+  //   display: inline-block;
+  //   font-size: 16px;
+  // }
+  // .item-button-right
+
+  .message-container {
+    width: 100vw;
+  }
+  .message-content {
+    padding: 24px 7.5%;
+    background: #fff;
+  }
+  .item-button-left {
+    float: none;
+  }
+
+  .item-button-right {
+    float: none;
+    margin: 16px 0 0;
+  }
+  .item-btn-float-area>.item-buy-btn {
+    margin-top: 0;
+  }
+
+  .visible-sp {
+    width: 649px;
+  }
+
+  .item-btn-float-area {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    padding: 6px 16px;
+    width: 100%;
+    background-color: #fff;
+    z-index: 3;
+    -webkit-box-shadow: 0 -1px 3px 0 rgba(0,0,0,0.16);
+    box-shadow: 0 -1px 3px 0 rgba(0,0,0,0.16);
+  }
+
+  .item-buy-btn {
+    display: block;
+    margin-top: 16px;
+    background: #ea352d;
+    font-size: 14px;
+    color: #fff;
+    line-height: 56px;
+    text-align: center;
+    font-weight: 600;
+    -webkit-transition: all ease-out .3s;
+    transition: all ease-out .3s;
+    // width: 100vw;
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   def index
+    @items=Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all.limit(4)
+    @items = Item.order('id ASC').limit(4)
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,12 @@
 class ItemsController < ApplicationController
   def index
-    @items=Item.all
+    @items = Item.all.limit(4)
   end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
 
   def new
     @item = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.order('id ASC').limit(4)
+    @items = Item.order('id DESC').limit(4)
   end
 
   def show

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,11 +1,9 @@
 class MypageController < ApplicationController
   before_action :authenticate_user!
   def index
-    @user=User.find(current_user.id)
   end
 
   def profile
-    @user=User.find(current_user.id)
   end
 
   def notification

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,5 +1,7 @@
 class MypageController < ApplicationController
+  before_action :authenticate_user!
   def index
+    @user
   end
 
   def profile

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -5,6 +5,7 @@ class MypageController < ApplicationController
   end
 
   def profile
+    @user=User.find(current_user.id)
   end
 
   def notification
@@ -26,6 +27,10 @@ class MypageController < ApplicationController
   end
 
   def identification
+  end
+
+  def user_params
+    params.require(:user).permit(:nickname)
   end
 
 end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,7 +1,7 @@
 class MypageController < ApplicationController
   before_action :authenticate_user!
   def index
-    @user
+    @user=User.find(current_user.id)
   end
 
   def profile

--- a/app/models/social_profile.rb
+++ b/app/models/social_profile.rb
@@ -1,3 +1,10 @@
 class SocialProfile < ApplicationRecord
   belongs_to :user
+  validates :uid,
+    presence: true,
+    uniqueness: { message: "はすでに存在しています" }
+  validates :provider,
+    presence: true
+  validates :user_id,
+    presence: true
 end

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -36,113 +36,18 @@
       %h2.pickup__container__title ピックアップカテゴリー
       %section.items
         %h3.items__heading
-          = link_to "/jp/category/1/" do
+          = link_to "#" do
             レディース 新着アイテム
         .items__boxs
-          %section.items__box
-            = link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            = link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            = link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            = link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,200
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
+          = render partial: 'items/partial/item_box', collection: @items, as:'item'
         .view__all
           =link_to "すべての商品を見る","https://www.mercari.com/jp/category/1/"
-
       %section.items
         %h3.items__heading
           =link_to "/jp/category/1/" do
-            レディース 新着アイテム
+            メンズ 新着アイテム
         .items__boxs
-          %section.items__box
-            =link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            =link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            =link_to  "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
-          %section.items__box
-            =link_to "https://item.mercari.com/jp/m74747117568/" do
-              %figure.items__box__photo
-                = image_tag "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614", class: " is-higher-height lazyloaded", alt: "新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L", width: "213", height: "251.13", data: {src: "https://static.mercdn.net/thumb/photos/m74747117568_1.jpg?1562932614"}
-              .items__box__body
-                %h3.items__box__name
-                  新品❇︎コムサイズム❇︎半袖T❇︎フロントタック❇︎L
-                .items__box__num
-                  .items__box__price ¥ 1,100
-                  .items__box__icon
-                    = fa_icon 'heart', class: "icon-like-border"
-                    %span 14
+          = render partial: 'items/partial/item_box', collection: @items, as:'item'
         .view__all
           =link_to "すべての商品を見る", "https://www.mercari.com/jp/category/1/"
       = render 'layouts/footer'
@@ -243,4 +148,3 @@
   =link_to new_item_path, class: "footer__sell-btn" do
     .footer__sell-btn__title 出品
     = fa_icon 'camera', class: "fa-3x"
-

--- a/app/views/items/partial/_item_box.html.haml
+++ b/app/views/items/partial/_item_box.html.haml
@@ -1,5 +1,5 @@
 %section.items__box
-  = link_to "/items/#{item.id}" , method: :get do
+  = link_to  item_path(item), method: :get do
     %figure.items__box__photo
       = image_tag item.item_images.first.image_url.url
     .items__box__body

--- a/app/views/items/partial/_item_box.html.haml
+++ b/app/views/items/partial/_item_box.html.haml
@@ -7,7 +7,7 @@
         = item.name
       .items__box__num
         .items__box__price
-          =item.price
+          ¥#{item.price}
         .items__box__icon
           = fa_icon 'heart', class: "icon-like-border"
           %span 14

--- a/app/views/items/partial/_item_box.html.haml
+++ b/app/views/items/partial/_item_box.html.haml
@@ -1,0 +1,13 @@
+%section.items__box
+  = link_to "/items/#{item.id}" , method: :get do
+    %figure.items__box__photo
+      = image_tag item.item_images.first.image_url.url
+    .items__box__body
+      %h3.items__box__name
+        = item.name
+      .items__box__num
+        .items__box__price
+          =item.price
+        .items__box__icon
+          = fa_icon 'heart', class: "icon-like-border"
+          %span 14

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -66,7 +66,7 @@
             =@item.shipping.handling_time
   .item-price-box.text-center
     %span.item-price.bold
-      =@item.price
+      ¥#{@item.price}
     %span.item-tax （税込）
     %span.item-shipping-fee (仮)送料込み
   = link_to "購入画面に進む", "#", class: "item-buy-btn"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,136 @@
+.item-box-container.l-single-container
+  %h1.item-name ショルダーバック なこびす
+  .item-main-content.clearfix
+    .item-photo
+      .owl-carousel.owl-loaded.owl-drag
+        .owl-stage-outer
+          .owl-stage
+            .owl-item.active{style: "width: 300px;"}
+              .owl-item-inner
+                = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900", alt: "ショルダーバッグ", class: "owl-lazy", style: "opacity: 1;", data: {src: "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900"}
+            .owl-item-java{style: "width: 300px;"}
+              .owl-item-inner
+                = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900", alt: "ショルダーバッグ", class: "owl-lazy", style: "opacity: 1;", data: {src: "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900"}
+        .owl-nav.disabled
+          .owl-prev
+          .owl-next
+        .owl-dots
+          .owl-dot.active
+            %span
+            .owl-dot-inner
+              = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900"
+          .owl-dot
+            %span
+            .owl-dot-inner
+              = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900"
+    %table.item-detail-table
+      %tbody
+        %tr
+          %th 出品者
+          %td
+            = link_to 'なこびす', "#"
+            .div
+              .item-user-ratings
+                %i.fa.fa-smile
+                %span 32
+              .item-user-ratings
+                %i.fa.fa-meh
+                %span 1
+              .item-user-ratings
+                %i.fa.fa-frown
+                %span 0
+        %tr
+          %th カテゴリー
+          %td
+            = link_to "#" do
+              .div レディース
+            = link_to "#" do
+              .item-detail-table-sub-category
+                %i.fa.fa-angle-right
+                バッグ
+            = link_to "#" do
+              .item-detail-table-sub-sub-category
+                %i.fa.fa-angle-right
+                ショルダーバッグ
+        %tr
+          %th ブランド
+          %td
+            = link_to "#" do
+              フォーエバートゥエンティーワン
+        %tr
+          %th  商品の状態
+          %td 目立った傷や汚れ無し
+        %tr
+          %th  配送料の負担
+          %td 送料込み（出品者負担）
+        %tr
+          %th 配送の方法
+          %td 未定
+        %tr
+          %th 配送元地域
+          %td 未定
+        %tr
+          %th 発送日の目安
+          %td 2~3日で発送
+  .item-price-box.text-center
+    %span.item-price.bold ¥1,200
+    %span.item-tax （税込）
+    %span.item-shipping-fee 送料込み
+  = link_to "購入画面に進む", "https://www.mercari.com/jp/transaction/buy/m32062559021/?_s=U2FsdGVkX1_BGYD_5_kfaamibA29iBGTJ7hp6RFf-LXwCDYFkrasMLfvBDSISPVPoQB00rbfDhYCmkYfoV3fwMvnzMRhjLxF2aOdri_9jdEYXGIxVaZxUppraWh6kejA", class: "item-buy-btn"
+  .item-description.f14
+    %p.item-description-inner forever21で購入しました!
+  .item-button-container.clearfix
+    .item-button-left
+      = button_tag "", type: "button", name: "like", data: {toggle: "like"}, data: {id: "m32062559021"}, data: {ga: "element"}, data: {'ga-category': "LIKE"}, class: "item-button item-button-like is-liked" do
+        %i.fa.fa-heart
+        %span いいね！
+        %span{ class: "fade-in-down", data: {num: "like"} } 2
+      = button_tag "",  class: "item-button item-button-report clearfix", data: {open: "modal"}, data: {modal: "report-item"} do
+        %i.fa.fa-flag
+        %span 不適切な商品の報告
+        %input{ type: "hidden"}
+        %input{ type: "hidden"}
+        %input{ type: "hidden"}
+    .item-button-right
+      = link_to "https://www.mercari.com/jp/safe/description/", target: "_blank" do
+        %i.fa.fa-lock
+        %span あんしん・あんぜんへの取り組み
+.item-detail-message
+  .message-container
+    .message-content
+      %form.message-form{action: "https://www.mercari.com/jp/comment/add/", method: "POST"}
+        %input{ type: "hidden"}
+        %p 相手のことを考え丁寧なコメントを心がけましょう。不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        %input{ type: "hidden"}
+        %input{ type: "hidden"}
+        %textarea{ type: "text", name: "body", class: "textarea-default"}
+        = button_tag "コメントする", type: "submit",  class: "message-submit btn-default btn-gray"
+%ul.nav-item-link-prev-next.clearfix
+  %li.nav-item-link-prev
+    =link_to "#" do
+      %i.fa.fa-angle-left
+      ウォール KM2 SPEED ペット用バリカン
+  %li.nav-item-link-next
+    = link_to "#"  do
+      プティマイン トップス 90 記名あり
+      %i.fa.fa-angle-right
+.item-social-media-box
+  .text-center
+  %ul.social-media-box
+    %li
+      = link_to "http://www.facebook.com/share.php?u=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F", target: "_blank", class: "share-btn", data: {'window-name': "facebook_window"} do
+        %i.fa.fa-facebook-square
+    %li
+      = link_to "http://twitter.com/share?count=horizontal&original_referer=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F&text=%E3%82%B7%E3%83%A7%E3%83%AB%E3%83%80%E3%83%BC%E3%83%90%E3%83%83%E3%82%B0%20%28%C2%A51%2C200%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89", target:"_blank", class: "share-btn", data: { 'window-name': "twitter_window" } do
+        %i.fa.fa-twitter-square
+    %li.social-hidden-item
+      = link_to "http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
+        %i.fab.fa-line
+    %li
+      = link_to href="http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
+        %i.fa.fa-pinterest-square
+.items-in-user-profile
+.visible-sp
+  .item-btn-float-area
+    = link_to "購入画面に進む", "https://www.mercari.com/jp/transaction/buy/m32062559021/?_s=U2FsdGVkX1_BGYD_5_kfaamibA29iBGTJ7hp6RFf-LXwCDYFkrasMLfvBDSISPVPoQB00rbfDhYCmkYfoV3fwMvnzMRhjLxF2aOdri_9jdEYXGIxVaZxUppraWh6kejA", class: "item-buy-btn "
+  -# = render 'layouts/footer'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,7 @@
+= render 'layouts/header'
 .item-box-container.l-single-container
-  %h1.item-name ショルダーバック なこびす
+  %h1.item-name
+    =@item.name
   .item-main-content.clearfix
     .item-photo
       .owl-carousel.owl-loaded.owl-drag
@@ -7,28 +9,14 @@
           .owl-stage
             .owl-item.active{style: "width: 300px;"}
               .owl-item-inner
-                = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900", alt: "ショルダーバッグ", class: "owl-lazy", style: "opacity: 1;", data: {src: "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900"}
-            .owl-item-java{style: "width: 300px;"}
-              .owl-item-inner
-                = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900", alt: "ショルダーバッグ", class: "owl-lazy", style: "opacity: 1;", data: {src: "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900"}
-        .owl-nav.disabled
-          .owl-prev
-          .owl-next
-        .owl-dots
-          .owl-dot.active
-            %span
-            .owl-dot-inner
-              = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_1.jpg?1566990900"
-          .owl-dot
-            %span
-            .owl-dot-inner
-              = image_tag "https://static.mercdn.net/item/detail/orig/photos/m32062559021_2.jpg?1566990900"
+                = image_tag @item.item_images.first.image_url.url
     %table.item-detail-table
       %tbody
         %tr
           %th 出品者
           %td
-            = link_to 'なこびす', "#"
+            = link_to '/' do
+              =@item.user.nickname
             .div
               .item-user-ratings
                 %i.fa.fa-smile
@@ -43,42 +31,48 @@
           %th カテゴリー
           %td
             = link_to "#" do
-              .div レディース
+              .div (仮)レディース
             = link_to "#" do
               .item-detail-table-sub-category
                 %i.fa.fa-angle-right
-                バッグ
+                (仮)バッグ
             = link_to "#" do
               .item-detail-table-sub-sub-category
                 %i.fa.fa-angle-right
-                ショルダーバッグ
+                (仮)ショルダーバッグ
         %tr
           %th ブランド
           %td
             = link_to "#" do
-              フォーエバートゥエンティーワン
+              (仮)フォーエバートゥエンティーワン
         %tr
           %th  商品の状態
-          %td 目立った傷や汚れ無し
+          %td
+            =@item.condition
         %tr
           %th  配送料の負担
-          %td 送料込み（出品者負担）
+          %td
+            =@item.shipping.fee_burden
         %tr
           %th 配送の方法
           %td 未定
         %tr
           %th 配送元地域
-          %td 未定
+          %td
+            =@item.shipping.area
         %tr
           %th 発送日の目安
-          %td 2~3日で発送
+          %td
+            =@item.shipping.handling_time
   .item-price-box.text-center
-    %span.item-price.bold ¥1,200
+    %span.item-price.bold
+      =@item.price
     %span.item-tax （税込）
-    %span.item-shipping-fee 送料込み
-  = link_to "購入画面に進む", "https://www.mercari.com/jp/transaction/buy/m32062559021/?_s=U2FsdGVkX1_BGYD_5_kfaamibA29iBGTJ7hp6RFf-LXwCDYFkrasMLfvBDSISPVPoQB00rbfDhYCmkYfoV3fwMvnzMRhjLxF2aOdri_9jdEYXGIxVaZxUppraWh6kejA", class: "item-buy-btn"
+    %span.item-shipping-fee (仮)送料込み
+  = link_to "購入画面に進む", "#", class: "item-buy-btn"
   .item-description.f14
-    %p.item-description-inner forever21で購入しました!
+    %p.item-description-inner
+      =@item.text
   .item-button-container.clearfix
     .item-button-left
       = button_tag "", type: "button", name: "like", data: {toggle: "like"}, data: {id: "m32062559021"}, data: {ga: "element"}, data: {'ga-category': "LIKE"}, class: "item-button item-button-like is-liked" do

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2,7 +2,7 @@
   .pc-header__box
     .pc-header__box__top
       %h1
-        = link_to "https://www.mercari.com/jp/" do
+        = link_to root_path do
           = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?2787198863", alt: "mercari", width: "134", height: "36"
       %form.pc-header__box__form
         %input.pc-header__box__form__input-box{ type: "search", name: "keyword", placeholder: "何かお探しですか？", kl_vkbd_parsed: "true" }

--- a/app/views/mypage/index.html.haml
+++ b/app/views/mypage/index.html.haml
@@ -7,7 +7,8 @@
       = link_to  "https://www.mercari.com/jp/u/952910795/" do
         .mypage-user__img
           =image_tag "http://placehold.jp/cc9999/993333/60x60.png"
-        %h2.mypage-user__name AYA☆セールしてない
+        %h2.mypage-user__name
+          =@user.nickname
         .mypage-user__number
           .mypage-user__number--title
             評価

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -6,12 +6,12 @@
     .profile
       .profile__head プロフィール
       .profile__form
-        = form_with model: @user do |f|
+        = form_with url:mypage_index_path ,locale: true do |f|
           .profile__icon
             .profile__img
               = image_tag "http://placehold.jp/cc9999/993333/60x60.png"
-            = f.text_field :nickname, class:'profile__nickname',placeholder:"例)AYA☆セール中"
+            = f.text_field :nickname, class:'profile__nickname', value: "#{@user.nickname}",placeholder:"例)AYA☆セール中"
           .profile__content
-            = f.text_area :introduction, class:'profile__introduction',placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"
+            -# = f.text_area :introduction, class:'profile__introduction',placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"
             = f.submit '変更する',class:'profile__btn'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/spec/factories/social_profile.rb
+++ b/spec/factories/social_profile.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :social_profile do
-    provider            {"google"}
+    provider            {"facebook"}
     uid                 {"1234567890"}
-    user_id             { "1" }
+    user_id             { 1 }
   end
 end

--- a/spec/models/social_profile_spec.rb
+++ b/spec/models/social_profile_spec.rb
@@ -1,5 +1,51 @@
 require 'rails_helper'
 
-RSpec.describe SocialProfile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe SocialProfile, type: :model do
+  describe '#user_params' do
+
+    before do
+      user = create(:user, id: 1)
+    end
+
+    context "can save" do
+
+      # 登録可能（全項目あり）
+      it "is valid with uid, provider and user_id" do
+        sns = build(:social_profile)
+        expect(sns).to be_valid
+      end
+    end
+
+    context "can't save" do
+
+      # 登録不可能（uidなし）
+      it "is invalid without uid" do
+        sns = build(:social_profile, uid: nil)
+        sns.valid?
+        expect(sns.errors[:uid]).to include("を入力してください")
+      end
+
+      # 登録不可能（providerなし）
+      it "is invalid without provider" do
+        sns = build(:social_profile, provider: nil)
+        sns.valid?
+        expect(sns.errors[:provider]).to include("を入力してください")
+      end
+
+      # 登録不可能（user_idなし）
+      it "is invalid without user_id" do
+        sns = build(:social_profile, user_id: nil)
+        sns.valid?
+        expect(sns.errors[:user_id]).to include("を入力してください")
+      end
+
+      # 登録不可能（uidの一意性）
+      it "is invalid with not unique uid" do
+        sns = create(:social_profile)
+        sns2 = build(:social_profile,uid: sns.uid)
+        sns2.valid?
+        expect(sns2.errors[:uid]).to include("はすでに存在しています")
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,9 +89,9 @@ describe User do
     # 登録不可能(一意性)
     it "is invalid with a duplicate email address" do
       user = create(:user)
-      another_user = build(:user, email: user.email)
-      another_user.valid?
-      expect(another_user.errors[:email]).to include("はすでに存在します")
+      user2 = build(:user, email: user.email)
+      user2.valid?
+      expect(user2.errors[:email]).to include("はすでに存在します")
     end
 
     # 登録不可能（フォーマットエラー：email、@なし）


### PR DESCRIPTION
### WHAT
・出品した商品がTOPページに表示される
・TOPページの商品をクリックすると商品の詳細ページへ遷移する

### WHY
・商品購入の導線に必須のため

### 備考
・商品一覧ページのビューは最近、本物のが更新されたようで、完全な一致はしてません。
・商品詳細ページのビューは、ビューの崩れがあります。他のメンバーが編集するので今後改修します。

**出品機能に不足分(カテゴリー・enumの設定等)があるため下記が本物と違います**
・TOPに表示している商品は、、すべての商品でidの数字が小さい順になっています。
・商品詳細ページの、カテゴリ・ブランドは仮置です。仮置のところには(仮)と記載しております。
・商品詳細ページの、商品の状態（未表示）、送料の負担、配送の方法、配送元地域、発送日の目安が、正常に表示されていません。
・画像が1枚しか投稿できないので、商品詳細ページで画像が１枚しか表示されません。


### IMAGE

[![商品一覧から商品詳細への遷移](https://i.gyazo.com/75afcebceb98652de07ed83cbfb6f400.gif)](https://gyazo.com/75afcebceb98652de07ed83cbfb6f400)
