### PR TITLE
プロフィールのニックネーム

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,6 @@ Association
 
 - belongs_to :user
 
-***
-
-## user_detailテーブル
-
-| Column       | Type       | Options               |
-| ------------ | ---------- | --------------------- |
-| user_id      | references | null: false, FK: true |
-| nickname     | string     | null: false           |
-| introduction | text       |                       |
-|              |            |                       |
-
-Association
-
-- belongs_to :user
 
 ***
 
@@ -304,4 +290,4 @@ Association
 
 ## ER図
 
-[![ER図](https://imgur.com/a/O1PBNDZ)
+[Imgur](https://imgur.com/bIaAf9t)

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -12,7 +12,6 @@ class MypageController < ApplicationController
     if @user.update(profile_params)
       flash[:notice] = 'プロフィールを更新しました'
       redirect_to profile_mypage_index_path
-
     else
       render :profile
     end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -9,9 +9,10 @@ class MypageController < ApplicationController
 
   def profile_update
     @user=current_user
-    binding.pry
     if @user.update(profile_params)
-      redirect_to root_path
+      flash[:notice] = 'プロフィールを更新しました'
+      redirect_to profile_mypage_index_path
+
     else
       render :profile
     end
@@ -38,8 +39,10 @@ class MypageController < ApplicationController
   def identification
   end
 
+  private
+
   def profile_params
-    params.require(:user).permit(:nickname)
+    params.require(:user).permit(:nickname,:introduction)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,14 @@ class User < ApplicationRecord
   has_one :deliver_adress
   accepts_nested_attributes_for :deliver_adress
 
+
   VALID_EMAIL_REGEX =                 /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   VALID_KANA_REGEX  =                 /\A[ァ-ヶー－]+\z/
 
   validates :nickname,                presence: true, length: {maximum: 20}
   validates :email,                   presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :password,                presence: true, length: {minimum: 6, maximum: 128},on: :save_to_session_before_phone
-  validates :password_confirmation,   presence: true, confirmation: true, presence: true
+  validates :password_confirmation,   presence: true, confirmation: true, on: :create
   validates :family_name,             presence: true
   validates :first_name,              presence: true
   validates :family_name_kana,        presence: true, format: { with: VALID_KANA_REGEX }

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,0 +1,3 @@
+class UserDetail < ApplicationRecord
+  belongs_to :user
+end

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -10,8 +10,8 @@
           .profile__icon
             .profile__img
               = image_tag "http://placehold.jp/cc9999/993333/60x60.png"
-            = f.text_field :nickname, class:'profile__nickname', value: current_user.nickname,placeholder:"例)AYA☆セール中"
+            = f.text_field :nickname, class:'profile__nickname', placeholder:"例)AYA☆セール中"
           .profile__content
-            -# = f.text_area :introduction, class:'profile__introduction',placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"
+            = f.text_area :introduction, class:'profile__introduction',placeholder:"例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"
             = f.submit '変更する',class:'profile__btn'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'profile/edit'
   devise_for :users,  controllers: {
     registrations: 'users/registrations' ,
     omniauth_callbacks: 'users/omniauth_callbacks'
@@ -17,6 +18,7 @@ Rails.application.routes.draw do
       get "identification"
     end
   end
+
   resources :items
   resources :signup do
     collection do

--- a/db/migrate/20190902150347_create_user_details.rb
+++ b/db/migrate/20190902150347_create_user_details.rb
@@ -1,0 +1,5 @@
+class CreateUserDetails < ActiveRecord::Migration[5.2]
+  def change
+
+  end
+end

--- a/db/migrate/20190902154130_add_column_users.rb
+++ b/db/migrate/20190902154130_add_column_users.rb
@@ -1,0 +1,5 @@
+class AddColumnUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :introduction, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_02_081325) do
+ActiveRecord::Schema.define(version: 2019_09_02_154130) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 2019_09_02_081325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nickname", null: false
+    t.text "introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
### WHAT
・プロフィールのニックネームとイントロダクション更新機能追加
・更新したときにフラッシュメッセージ
・READ.MEの変更（user_detailsテーブルにinroroductionを設定していたがuserテーブルへ移行しuser_detailsテーブルを削除）
・createの時にしかuserモデルpassword_confirmationのバリデーションが適用されるように変更。

### WHY
・ユーザー情報を書き込むことで、出品者の情報を購入者へ伝えるため。

### GIF
[![Image from Gyazo](https://i.gyazo.com/558767b8438671d969a018cb9de979a1.gif)](https://gyazo.com/558767b8438671d969a018cb9de979a1)

