### PR TITLE
turbolinksを削除するとCSSのみで作成したリンク付きタブがリンク先に遷移しなくなったので書き直しとプロフィール更新をform_forで書き直し

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,9 +334,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    turbolinks (5.2.0)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -409,7 +406,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)

--- a/app/assets/stylesheets/modules/mypage/_listings.scss
+++ b/app/assets/stylesheets/modules/mypage/_listings.scss
@@ -5,7 +5,7 @@
   font-size: 16px;
   line-height: 72px;
 }
-.listing-tab { /*タブ切り替え全体のスタイル*/
+.listing-tab {
   background-color: #fff;
   &__item{ /*タブのスタイル*/
     width: calc(100%/3);
@@ -26,20 +26,13 @@
   }
 }
 
-/*ラジオボタンを全て消す*/
-input[name="listing-tab__item"] {
-  display: none;
-}
 
-/*選択されているタブのコンテンツのみを表示*/
-#listing:checked ~ #listings-content,
-#in_progress:checked ~ #listings-content,
-#completed:checked ~ #listings-content {
-  display: block;
-}
 
 /*選択されているタブのスタイルを変える*/
-.listing-tab input:checked + .listing-tab__item{
+#active-tab{
   background-color: #fff;
   border-top: 2px solid #ea352d;
+}
+#listings-content {
+  display: block;
 }

--- a/app/assets/stylesheets/modules/mypage/_mypage.scss
+++ b/app/assets/stylesheets/modules/mypage/_mypage.scss
@@ -29,7 +29,7 @@ input[name="mypage-tab__item2"] {
   display: none;
 }
 
-/*選択されているタブのコンテンツのみを表示*/
+/*選択されているタブのコンテンツのみを表示(index.html.haml用)*/
 #notification:checked ~ #notification-content,
 #todo:checked ~ #todo-content {
   display: block;
@@ -40,6 +40,14 @@ input[name="mypage-tab__item2"] {
 #purchased:checked ~ #purchased-content {
   display: block;
 }
+/*選択されているタブのコンテンツのみを表示(各個別ファイル用)*/
+#active-tab~ #notification-content,
+#active-tab~ #todo-content,
+#active-tab~ #purchase-content,
+#active-tab~ #purchased-content {
+  display: block;
+}
+
 
 /*選択されているタブのスタイルを変える*/
 .mypage-tab input:checked + .mypage-tab__item{

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -4,7 +4,7 @@ class ListingsController < ApplicationController
   end
 
   def in_progress
-    @items=Item.where(user_id:current_user.id)
+    @items=Item.find(8,11)
   end
 
   def completed

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -4,7 +4,7 @@ class ListingsController < ApplicationController
   end
 
   def in_progress
-    @items=Item.find(8,11)
+    @items=Item.where(user_id:current_user.id)
   end
 
   def completed

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/flash'
     -# .breadcrumb

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,7 @@
     %title Mercarisample
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render 'layouts/flash'

--- a/app/views/listings/completed.html.haml
+++ b/app/views/listings/completed.html.haml
@@ -7,13 +7,8 @@
     %h2.listing-tab-head 出品した商品
     %section
       .listing-tab
-        %input#listing{name: "listing-tab__item", type: "radio"}/
-        = link_to  listing_listings_path do
-          %label.listing-tab__item{for: "listing"} 出品中
-        %input#in_progress{name: "listing-tab__item", type: "radio"}/
-        = link_to  in_progress_listings_path do
-          %label.listing-tab__item{for: "in_progress"} 取引中
-        %input#completed{name: "listing-tab__item", type: "radio",checked: "checked" }/
-        %label.listing-tab__item{for: "completed"} 売却済み
+        = link_to '出品中',listing_listings_path , class:"listing-tab__item",id: "listing"
+        = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
+        #active-tab.listing-tab__item 売却済み
         = render 'listings/shared/listings-content'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/in_progress.html.haml
+++ b/app/views/listings/in_progress.html.haml
@@ -6,13 +6,8 @@
     %h2.listing-tab-head 出品した商品
     %section
       .listing-tab
-        %input#listing{name: "listing-tab__item", type: "radio"}/
-        = link_to  listing_listings_path do
-          %label.listing-tab__item{for: "listing"} 出品中
-        %input#in_progress{name: "listing-tab__item", type: "radio",checked: "checked" }/
-        %label.listing-tab__item{for: "in_progress"} 取引中
-        %input#completed{name: "listing-tab__item", type: "radio"}/
-        = link_to  completed_listings_path do
-          %label.listing-tab__item{for: "completed"} 売却済み
+        = link_to '出品中',listing_listings_path , class:"listing-tab__item",id: "listing"
+        #active-tab.listing-tab__item 取引中
+        = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/listing.html.haml
+++ b/app/views/listings/listing.html.haml
@@ -6,13 +6,8 @@
     %h2.listing-tab-head 出品した商品
     %section
       .listing-tab
-        %input#listing{name: "listing-tab__item", type: "radio",checked: "checked" }/
-        %label.listing-tab__item{for: "listing"} 出品中
-        %input#in_progress{name: "listing-tab__item", type: "radio"}/
-        = link_to  in_progress_listings_path do
-          %label.listing-tab__item{for: "in_progress"} 取引中
-        %input#completed{name: "listing-tab__item", type: "radio"}/
-        = link_to  in_progress_listings_path do
-          %label.listing-tab__item{for: "completed"} 売却済み
+        #active-tab.listing-tab__item 出品中
+        = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
+        = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/mypage/notification.html.haml
+++ b/app/views/mypage/notification.html.haml
@@ -5,11 +5,13 @@
   .my-content
     %section.notification-todo
       .mypage-tab
-        %input#notification{name: "mypage-tab__item1", type: "radio",checked: "checked" }/
-        %label.mypage-tab__item{for: "notification"} お知らせ
-        %input#todo{name: "mypage-tab__item1", type: "radio"}/
-        = link_to  todo_mypage_index_path do
-          %label.mypage-tab__item{for: "todo"} やることリスト
+        #active-tab.mypage-tab__item お知らせ
+        = link_to 'やることリスト',todo_mypage_index_path , class:"mypage-tab__item",id: "todo"
+        %ul#notification-content.mypage-content__list
+          - if notifications ==[]
+            .mypage-content__not-found
+              現在、お知らせはありません
+          - else
+            = render partial:'mypage/shared/tabs/contents/notification', collection: notifications, as:'notification'
 
-        = render 'mypage/shared/tabs/notification-todo'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -6,7 +6,7 @@
     .profile
       .profile__head プロフィール
       .profile__form
-        = form_with model: @user, url:profile_update_mypage_index_path, method: :patch ,locale: true do |f|
+        = form_for(@user, url:profile_update_mypage_index_path(@user),html:{ method: "patch"} ) do |f|
           .profile__icon
             .profile__img
               = image_tag "http://placehold.jp/cc9999/993333/60x60.png"

--- a/app/views/mypage/purchase.html.haml
+++ b/app/views/mypage/purchase.html.haml
@@ -5,11 +5,12 @@
   .my-content
     %section.purchase-purchased
       .mypage-tab
-        %input#purchase{name: "mypage-tab__item2", type: "radio",checked: "checked" }/
-        %label.mypage-tab__item{for: "purchase"} 取引中
-        %input#purchased{name: "mypage-tab__item2", type: "radio"}/
-        = link_to  purchased_mypage_index_path do
-          %label.mypage-tab__item{for: "purchased"} 過去の取引
-
-        = render 'mypage/shared/tabs/purchase-purchased'
+        #active-tab.mypage-tab__item 取引中
+        = link_to '過去の取引',purchased_mypage_index_path, class:"mypage-tab__item",id: "purchased"
+        %ul#purchase-content.mypage-content__list
+          - if purchases ==[]
+            .mypage-content__not-found
+              取引中の処品はありません
+          - else
+            = render partial:'mypage/shared//tabs/contents/purchase', collection: purchases, as:'purchase'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/mypage/purchased.html.haml
+++ b/app/views/mypage/purchased.html.haml
@@ -5,11 +5,12 @@
   .my-content
     %section.purchase-purchased
       .mypage-tab
-        %input#purchase{name: "mypage-tab__item2", type: "radio"}/
-        = link_to  purchase_mypage_index_path do
-          %label.mypage-tab__item{for: "purchase"} 取引中
-        %input#purchased{name: "mypage-tab__item2", type: "radio",checked: "checked" }/
-        %label.mypage-tab__item{for: "purchased"} 過去の取引
-
-        = render 'mypage/shared/tabs/purchase-purchased'
+        = link_to '取引中',purchase_mypage_index_path, class:"mypage-tab__item",id: "purchase"
+        #active-tab.mypage-tab__item 過去の取引
+        %ul#purchased-content.mypage-content__list
+          - if purchaseds ==[]
+            .mypage-content__not-found
+              過去の取引はありません
+          - else
+            = render partial:'mypage/shared/tabs/contents/purchased', collection: purchaseds, as:'purchased'
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/mypage/todo.html.haml
+++ b/app/views/mypage/todo.html.haml
@@ -5,11 +5,12 @@
   .my-content
     %section.notification-todo
       .mypage-tab
-        %input#notification{name: "mypage-tab__item1", type: "radio" }/
-        = link_to  notification_mypage_index_path do
-          %label.mypage-tab__item{for: "notification"} お知らせ
-        %input#todo{name: "mypage-tab__item1", type: "radio",checked: "checked"}/
-        %label.mypage-tab__item{for: "todo"} やることリスト
-
-        = render 'mypage/shared/tabs/notification-todo'
+        = link_to 'お知らせ',notification_mypage_index_path , class:"mypage-tab__item",id: "notification"
+        #active-tab.mypage-tab__item やることリスト
+        %ul#todo-content.mypage-content__list
+          - if todos ==[]
+            .mypage-content__not-found
+              現在、やることリストはありません
+          - else
+            = render partial:'mypage/shared/tabs/contents/todo', collection: todos, as:'todo'
   = render 'mypage/shared/sidemenus/sidemenu'


### PR DESCRIPTION
### WHAT
[1] turbolinksを削除するとCSSのみで作成したリンク付きタブがリンク先に遷移しなくなったので書き直し
 [2] プロフィール更新をform_forで書き直し
### WHY
エラー対応のため
 [1]turbolinksがあれば正常に動くが、商品削除機能を実装した際に、trubolinksを削除すると動かくなり、メンターさんと2時間かけて解決をこころみましたが駄目でしたので、再度書き直しました。
 [2]プロフィール更新時にredirectが動いてない事象を発見したので、form_forに書き換えて修正ちなみに local: trueを追記してるにも関わらず、駄目だった。

### GIF
[1]
[![Image from Gyazo](https://i.gyazo.com/e009e3efe119d56866a372bd1b48a6e1.gif)](https://gyazo.com/e009e3efe119d56866a372bd1b48a6e1)
[![Image from Gyazo](https://i.gyazo.com/1f366714cba5253a8e56c1a7ef287326.gif)](https://gyazo.com/1f366714cba5253a8e56c1a7ef287326)

[2]
[![Image from Gyazo](https://i.gyazo.com/8d53aa97506f917fd7ad7b821243fc0a.gif)](https://gyazo.com/8d53aa97506f917fd7ad7b821243fc0a)

