### PR TITLE
購入機能の不具合改修

### DIFF
--- a/app/assets/stylesheets/modules/item/show.scss
+++ b/app/assets/stylesheets/modules/item/show.scss
@@ -409,6 +409,10 @@
   }
 }
 
+.forbidden {
+  cursor: not-allowed;
+}
+
 @media screen and (max-width: 768px) {
   .details-item-box__container {
     background: #fff;

--- a/app/assets/stylesheets/modules/item/show.scss
+++ b/app/assets/stylesheets/modules/item/show.scss
@@ -183,8 +183,7 @@
   transition: all ease-out .3s;
 }
 
-.details-item__description {
-  padding: 32px 0 0;
+.item-description {
   font-size: 18px;
   line-height: 1.5;
   &__inner {

--- a/app/views/items/partial/_user_logged_in.html.haml
+++ b/app/views/items/partial/_user_logged_in.html.haml
@@ -1,0 +1,9 @@
+- if @item.seller_id == current_user.id
+  %button#item-delete.modal-open-btn.btn-default.btn-gray
+    #{@seller.nickname}さんが出品した商品です。
+-elsif @item.trading_status == "complete"
+  %button#item-delete.modal-open-btn.btn-default.btn-gray
+    売り切れました。
+- else
+  = link_to confirmation_items_path, class: "item-buy-btn" do
+    購入画面に進む

--- a/app/views/items/partial/_user_logged_in.html.haml
+++ b/app/views/items/partial/_user_logged_in.html.haml
@@ -1,8 +1,8 @@
 - if @item.seller_id == current_user.id
-  %button#item-delete.modal-open-btn.btn-default.btn-gray
+  .btn-default.btn-gray.forbidden
     #{@seller.nickname}さんが出品した商品です。
 -elsif @item.trading_status == "complete"
-  %button#item-delete.modal-open-btn.btn-default.btn-gray
+  .btn-default.btn-gray.forbidden
     売り切れました。
 - else
   = link_to confirmation_items_path, class: "item-buy-btn" do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -81,8 +81,8 @@
     = link_to new_user_session_path, class: "item-buy-btn" do
       購入画面に進む
   .item-description.f14z
-    %p.item-description-inner
-      =@item.text
+    %p.item-description__inner
+      = simple_format(h(@item.text))
 
 
   .details-item-button__container.clearfix

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -76,15 +76,10 @@
     %span.item-shipping-fee (仮)送料込み
   -# 出品者は自分の商品は購入できない/売り切れ商品は購入できない条件分岐
   - if user_signed_in?
-    - if @item.seller_id == current_user.id
-      %button#item-delete.modal-open-btn.btn-default.btn-gray
-        #{@seller.nickname}さんが出品した商品です。
-    -elsif @item.trading_status == "complete"
-      %button#item-delete.modal-open-btn.btn-default.btn-gray
-        売り切れました。
-    - else
-      = link_to confirmation_items_path, class: "item-buy-btn" do
-        購入画面に進む
+    = render 'items/partial/user_logged_in'
+  - else
+    = link_to new_user_session_path, class: "item-buy-btn" do
+      購入画面に進む
   .item-description.f14z
     %p.item-description-inner
       =@item.text

--- a/app/views/purchases/done.html.haml
+++ b/app/views/purchases/done.html.haml
@@ -6,6 +6,6 @@
       %h2.purchase__container__head 購入ありがとうございます！
       %section.purchase__content
         .purchase-item
-          =link_to "/", class: "btn-default" do
+          =link_to root_path, class: "btn-default" do
             メルカリに戻る
   = render 'items/modules/footer'

--- a/app/views/purchases/done.html.haml
+++ b/app/views/purchases/done.html.haml
@@ -1,4 +1,11 @@
-.hoge
-  購入ありがとうございます！
-=link_to root_path do
-  メルカリに戻る
+-# ToDo:payjpボタンが仮起きの為、doneページ用意。モーダルウィンドウで購入完了画面実装予定
+.single-container
+  =render 'items/modules/header'
+  %main.purchase__main
+    %section.purchase__container
+      %h2.purchase__container__head 購入ありがとうございます！
+      %section.purchase__content
+        .purchase-item
+          =link_to "/", class: "btn-default" do
+            メルカリに戻る
+  = render 'items/modules/footer'


### PR DESCRIPTION
## WHAT

- 非ログインユーザーが購入するボタンを押すとログイン画面にリダイレクトする
- 購入完了画面のレイアウト修正
- 商品説明文に改行を適応させる

## WHY

- 非ログインユーザーが誤って購入画面に遷移しないようにする為
- 購入完了画面が仮置きだった為
- 改行が反映されず見にくい説明文の表示になっていた為

## image & gif

- ログイン画面へリダイレクト
https://gyazo.com/ab3fb54420911e2ffb1b2427cd4400e0
- 購入完了画面
https://gyazo.com/768b32ebeed5e98b992de5bee3b2d27a
- 改行を適応した画面
![スクリーンショット 2019-09-13 11 17 57](https://user-images.githubusercontent.com/51276845/64833597-8e36e700-d619-11e9-9fdc-9981a0df8d59.png)
