### PR TITLE
商品一覧にレディース・メンズのItem反映/詳細にカテゴリーなどのItemに定義されたカラムの表記反映/削除画面のCSSの崩れ修正/seed.rbの修正/その他細かい修正

### DIFF
--- a/app/assets/stylesheets/modules/item/show.scss
+++ b/app/assets/stylesheets/modules/item/show.scss
@@ -562,6 +562,7 @@
   color: #333;
 }
 .item-delete-btn {
+  box-sizing: border-box;
   float: right;
   border-left: 1px solid #ccc;
   color: #0099e8;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,11 +3,17 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:show]
   before_action :authenticate_user!, only:[:new]
   def index
-    @items = Item.order('id DESC').limit(4)
+    @ladies = Category.find_by(name:'レディース')
+    @mens = Category.find_by(name:'メンズ')
+    @item = Item.order('id DESC')
+    @ladies_items = @item.inject([]){|result,n| result << n if n.category.root.name=="レディース";result}.take(4)
+    @mens_items = @item.inject([]){|result,n| result << n if n.category.root.name=="メンズ";result}.take(4)
   end
 
   def show
     @seller = User.find(@item.seller_id)
+    @before_item = Item.where.not(seller_id: current_user.id).where.not(id: @item.id).where( 'id >= ?', rand(Item.first.id..Item.last.id)).first
+    @after_item = Item.where.not(seller_id: current_user.id).where.not(id: [@item.id,@before_item.id]).where( 'id >= ?', rand(Item.first.id..Item.last.id)).first
   end
 
   def new

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,13 +1,13 @@
 class ListingsController < ApplicationController
   def listing
-    @items=Item.where(seller_id:current_user.id,trading_status:0)
+    @items=Item.where(seller_id:current_user.id,trading_status:0).page(params[:page]).per(12)
   end
 
   def in_progress
-    @items=Item.where(seller_id:current_user.id,trading_status:1)
+    @items=Item.where(seller_id:current_user.id,trading_status:1..2).page(params[:page]).per(12)
   end
 
   def completed
-    @items=Item.where(seller_id:current_user.id,trading_status:2)
+    @items=Item.where(seller_id:current_user.id,trading_status:3).page(params[:page]).per(12)
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,13 +1,13 @@
 class ListingsController < ApplicationController
   def listing
-    @items=Item.where(seller_id:current_user.id)
+    @items=Item.where(seller_id:current_user.id,trading_status:0)
   end
 
   def in_progress
-    @items=Item.where(seller_id:current_user.id)
+    @items=Item.where(seller_id:current_user.id,trading_status:1)
   end
 
   def completed
-    @items=Item.where(seller_id:current_user.id)
+    @items=Item.where(seller_id:current_user.id,trading_status:2)
   end
 end

--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,6 +1,6 @@
 module PurchasesHelper
 
-  def seller_user?
+  def item_status_edit_or_item_comment?
     if user_signed_in?
       if @item.seller_id == current_user.id
         render 'items/partial/item_status_edit'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -16,8 +16,8 @@
           Googleでログイン
       .top-form
         = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-          =f.email_field :email, class: 'top-input-default', placeholder: 'メールアドレス'
-          =f.password_field :password, class: "top-login-input-password top-input-default", placeholder: 'パスワード'
+          =f.email_field :email, class: 'top-input-default', placeholder: 'メールアドレス', value:'sample1@sample.com'
+          =f.password_field :password, class: "top-login-input-password top-input-default", placeholder: 'パスワード', value:'password'
           .g-recaptcha.signup-recaptcha{"data-sitekey": "6LfZGCYTAAAAAHoK-s7Lg5OdYg5Fq4susvALmZoc"}
             %div{style: "width: 304px; height: 78px;"}
               %div

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -36,19 +36,18 @@
       %h2.pickup__container__title ピックアップカテゴリー
       %section.items
         %h3.items__heading
-          = link_to "#" do
+          = link_to category_path(@ladies) do
             レディース 新着アイテム
         .items__boxs
-          = render partial: 'items/partial/item_box', collection: @items, as:'item'
+          = render partial: 'items/partial/item_box', collection: @ladies_items, as:'item'
         .view__all
           =link_to "すべての商品を見る","https://www.mercari.com/jp/category/1/"
       %section.items
         %h3.items__heading
-          =link_to "/jp/category/1/" do
+          =link_to category_path(@mens) do
             メンズ 新着アイテム
         .items__boxs
-          = render partial: 'items/partial/item_box', collection: @items, as:'item'
+          = render partial: 'items/partial/item_box', collection: @mens_items, as:'item'
         .view__all
           =link_to "すべての商品を見る", "https://www.mercari.com/jp/category/1/"
       = render 'layouts/footer'
-

--- a/app/views/items/partial/_item_bottom_purchase-button.html.haml
+++ b/app/views/items/partial/_item_bottom_purchase-button.html.haml
@@ -1,0 +1,6 @@
+-if user_signed_in?
+  - unless @item.seller_id == current_user.id || @item.trading_status == "complete"
+    .visible-sp
+      .details-item__float-btn
+        = link_to confirmation_items_path, class: "item-buy-btn" do
+          購入画面に進む

--- a/app/views/items/partial/_item_buttons.html.haml
+++ b/app/views/items/partial/_item_buttons.html.haml
@@ -1,0 +1,17 @@
+- if @seller.id != current_user.id
+  .details-item-button__container.clearfix
+    .details-item-button__left
+      = button_tag "", type: "button", name: "like", data: {toggle: "like"}, data: {id: "m32062559021"}, data: {ga: "element"}, data: {'ga-category': "LIKE"}, class: "item-button item-button-like is-liked" do
+        %i.fa.fa-heart
+        %span いいね！
+        %span{ class: "fade-in-down", data: {num: "like"} } 2
+      = button_tag "",  class: "item-button item-button-report clearfix", data: {open: "modal"}, data: {modal: "report-item"} do
+        %i.fa.fa-flag
+        %span 不適切な商品の報告
+        %input{ type: "hidden"}
+        %input{ type: "hidden"}
+        %input{ type: "hidden"}
+    .details-item-button__right
+      = link_to "https://www.mercari.com/jp/safe/description/", target: "_blank" do
+        %i.fa.fa-lock
+        %span あんしん・あんぜんへの取り組み

--- a/app/views/items/partial/_item_suggestion.html.haml
+++ b/app/views/items/partial/_item_suggestion.html.haml
@@ -1,0 +1,10 @@
+- if @seller.id == current_user.id
+  %ul.details-item__link.clearfix
+    %li.details-item__link__prev
+      = link_to item_path(@before_item) do
+        %i.fa.fa-angle-left
+        = @before_item.name
+    %li.details-item__link__next
+      = link_to item_path(@after_item)  do
+        = @after_item.name
+        %i.fa.fa-angle-right

--- a/app/views/items/partial/_sns_links.html.haml
+++ b/app/views/items/partial/_sns_links.html.haml
@@ -1,0 +1,15 @@
+.details-item__social-media__boxs
+  .text-center
+  %ul.details-item__social-media__box
+    %li
+      = link_to "http://www.facebook.com/share.php?u=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F", target: "_blank", class: "share-btn", data: {'window-name': "facebook_window"} do
+        %i.fa.fa-facebook-square
+    %li
+      = link_to "http://twitter.com/share?count=horizontal&original_referer=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F&text=%E3%82%B7%E3%83%A7%E3%83%AB%E3%83%80%E3%83%BC%E3%83%90%E3%83%83%E3%82%B0%20%28%C2%A51%2C200%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89", target:"_blank", class: "share-btn", data: { 'window-name': "twitter_window" } do
+        %i.fa.fa-twitter-square
+    %li.details-item__social-hidden
+      = link_to "http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
+        %i.fab.fa-line
+    %li
+      = link_to "http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
+        %i.fa.fa-pinterest-square

--- a/app/views/items/partial/_user_logged_in.html.haml
+++ b/app/views/items/partial/_user_logged_in.html.haml
@@ -1,4 +1,4 @@
-- if @item.seller_id == current_user.id
+- if @seller.id == current_user.id
   .btn-default.btn-gray.forbidden
     #{@seller.nickname}さんが出品した商品です。
 -elsif @item.trading_status == "complete"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,7 +80,7 @@
         %tr
           %th 発送日の目安
           %td
-            =@item.shipping.handling_time_i18n
+            = @item.shipping.handling_time_i18n
   .details-item__price-box.text-center
     %span.details-item-price.bold
       ¥#{@item.price}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,7 +1,7 @@
 = render 'layouts/header'
 .details-item-box__container
   %h1.details-item-name
-    =@item.name
+    = @item.name
   .details-item__main-content.clearfix
     .details-item-photo
       .owl-carousel
@@ -21,7 +21,7 @@
           %th 出品者
           %td
             = link_to '/' do
-              =@seller.nickname
+              = @seller.nickname
             .div
               .item-user-ratings
                 %i.fa.fa-smile
@@ -35,45 +35,58 @@
         %tr
           %th カテゴリー
           %td
-            = link_to "#" do
-              .div (仮)レディース
-            = link_to "#" do
-              .details-item__table__sub-category1
-                %i.fa.fa-chevron-right
-                (仮)バッグ
-            = link_to "#" do
-              .details-item__table__sub-category2
-                %i.fa.fa-chevron-right
-                (仮)ショルダーバッグ
+            = link_to category_path(@item.category.root) do
+              .div
+                = @item.category.root.name
+            - if @item.category.root == @item.category.parent
+              = link_to category_path(@item.category)  do
+                .details-item__table__sub-category1
+                  %i.fa.fa-chevron-right
+                  = @item.category.name
+            - else
+              = link_to category_path(@item.category.parent) do
+                .details-item__table__sub-category1
+                  %i.fa.fa-chevron-right
+                  = @item.category.parent.name
+              = link_to category_path(@item.category) do
+                .details-item__table__sub-category2
+                  %i.fa.fa-chevron-right
+                  = @item.category.name
+        - if @item.size
+          %tr
+            %th サイズ
+            %td
+              = @item.size.kind
         %tr
           %th ブランド
           %td
             = link_to "#" do
-              (仮)フォーエバートゥエンティーワン
+              = @item.brand.name
         %tr
           %th  商品の状態
           %td
-            =@item.condition
+            = @item.condition_i18n
         %tr
           %th  配送料の負担
           %td
-            =@item.shipping.fee_burden
+            = @item.shipping.fee_burden_i18n
         %tr
           %th 配送の方法
           %td 未定
         %tr
           %th 配送元地域
           %td
-            =@item.shipping.area
+            = Prefecture.find(@item.shipping.area).name
         %tr
           %th 発送日の目安
           %td
-            =@item.shipping.handling_time
+            =@item.shipping.handling_time_i18n
   .details-item__price-box.text-center
     %span.details-item-price.bold
       ¥#{@item.price}
     %span.item-tax （税込）
-    %span.item-shipping-fee (仮)送料込み
+    %span.item-shipping-fee
+      = @item.shipping.fee_burden_i18n[/送料込み|着払い/]
   -# 出品者は自分の商品は購入できない/売り切れ商品は購入できない条件分岐
   - if user_signed_in?
     = render 'items/partial/user_logged_in'
@@ -83,56 +96,9 @@
   .item-description.f14z
     %p.item-description__inner
       = simple_format(h(@item.text))
-
-
-  .details-item-button__container.clearfix
-    .details-item-button__left
-      = button_tag "", type: "button", name: "like", data: {toggle: "like"}, data: {id: "m32062559021"}, data: {ga: "element"}, data: {'ga-category': "LIKE"}, class: "item-button item-button-like is-liked" do
-        %i.fa.fa-heart
-        %span いいね！
-        %span{ class: "fade-in-down", data: {num: "like"} } 2
-      = button_tag "",  class: "item-button item-button-report clearfix", data: {open: "modal"}, data: {modal: "report-item"} do
-        %i.fa.fa-flag
-        %span 不適切な商品の報告
-        %input{ type: "hidden"}
-        %input{ type: "hidden"}
-        %input{ type: "hidden"}
-    .details-item-button__right
-      = link_to "https://www.mercari.com/jp/safe/description/", target: "_blank" do
-        %i.fa.fa-lock
-        %span あんしん・あんぜんへの取り組み
-
-= seller_user?
-
-%ul.details-item__link.clearfix
-  %li.details-item__link__prev
-    =link_to "#" do
-      %i.fa.fa-angle-left
-      ウォール KM2 SPEED ペット用バリカン
-  %li.details-item__link__next
-    = link_to "#"  do
-      プティマイン トップス 90 記名あり
-      %i.fa.fa-angle-right
-.details-item__social-media__boxs
-  .text-center
-  %ul.details-item__social-media__box
-    %li
-      = link_to "http://www.facebook.com/share.php?u=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F", target: "_blank", class: "share-btn", data: {'window-name': "facebook_window"} do
-        %i.fa.fa-facebook-square
-    %li
-      = link_to "http://twitter.com/share?count=horizontal&original_referer=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F&text=%E3%82%B7%E3%83%A7%E3%83%AB%E3%83%80%E3%83%BC%E3%83%90%E3%83%83%E3%82%B0%20%28%C2%A51%2C200%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm32062559021%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89", target:"_blank", class: "share-btn", data: { 'window-name': "twitter_window" } do
-        %i.fa.fa-twitter-square
-    %li.details-item__social-hidden
-      = link_to "http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
-        %i.fab.fa-line
-    %li
-      = link_to "http://line.me/R/msg/text/?ショルダーバッグ%20%7C%20%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E3%81%8B%E3%82%93%E3%81%9F%E3%82%93%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%0D%0Ahttps://item.mercari.com/jp/m32062559021/", target: "_blank" do
-        %i.fa.fa-pinterest-square
--if user_signed_in?
-  - if @item.seller_id == current_user.id || @item.trading_status == "complete"
-  -else
-    .visible-sp
-      .details-item__float-btn
-        = link_to confirmation_items_path, class: "item-buy-btn" do
-          購入画面にすすむ
+  = render 'items/partial/item_buttons'
+= item_status_edit_or_item_comment?
+= render 'items/partial/item_suggestion'
+= render 'items/partial/sns_links'
+= render 'items/partial/item_bottom_purchase-button'
 = render 'layouts/footer'

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -40,11 +40,9 @@
                   %path{ fill: "currentColor", fill: {rule: "nonzero"}, d: "M6.682 12.657L1.67 7.642 0 9.313 6.682 16 21 1.672 19.33 0z"}
                 やることリスト
             %li.login-pc-header__nav-box__right__menu__list
-              = link_to "#", class: "header-svg-config header-svg-hover" do
+              = link_to mypage_index_path, class: "header-svg-config header-svg-hover" do
                 = image_tag("https://static.mercdn.net/images/member_photo_noimage_thumb.png", class: "sc-gwVKww header-face ")
                 マイページ
-            %li.pc-header__nav-box__right__menu__list
-              = link_to "ログアウト", destroy_user_session_path, class: "pc-header__nav__btn pc-header__nav__btn--red", method: :delete
           - else
             %li.pc-header__nav-box__right__menu__list
               = link_to "新規会員登録", step1_signup_index_path, class: "pc-header__nav__btn pc-header__nav__btn--red"

--- a/app/views/listings/completed.html.haml
+++ b/app/views/listings/completed.html.haml
@@ -11,5 +11,5 @@
         = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
         #active-tab.listing-tab__item 売却済み
         = render 'listings/shared/listings-content'
-  = paginate(@items)
+      = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/completed.html.haml
+++ b/app/views/listings/completed.html.haml
@@ -11,4 +11,5 @@
         = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
         #active-tab.listing-tab__item 売却済み
         = render 'listings/shared/listings-content'
+  = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/in_progress.html.haml
+++ b/app/views/listings/in_progress.html.haml
@@ -10,4 +10,5 @@
         #active-tab.listing-tab__item 取引中
         = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
+  = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/in_progress.html.haml
+++ b/app/views/listings/in_progress.html.haml
@@ -10,5 +10,5 @@
         #active-tab.listing-tab__item 取引中
         = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
-  = paginate(@items)
+      = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/listing.html.haml
+++ b/app/views/listings/listing.html.haml
@@ -10,4 +10,5 @@
         = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
         = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
+  = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/app/views/listings/listing.html.haml
+++ b/app/views/listings/listing.html.haml
@@ -10,5 +10,5 @@
         = link_to '取引中',in_progress_listings_path, class:"listing-tab__item",id: "in_progress"
         = link_to '売却済み',completed_listings_path, class:"listing-tab__item",id: "completed"
         = render 'listings/shared/listings-content'
-  = paginate(@items)
+      = paginate(@items)
   = render 'mypage/shared/sidemenus/sidemenu'

--- a/db/seeds/item.rb
+++ b/db/seeds/item.rb
@@ -1,4 +1,5 @@
 @category_sizes=CategorySize.all
+# @size=Size.where(ancestry: nil).chi
 (1..5).each do |m|
   @category_sizes.each.with_index(1) do |category_size,n|
     @item=Item.create!(name:"商品#{m}-#{n}_のカテゴリは"+Category.find(category_size.category_id).name,
@@ -7,7 +8,7 @@
                         condition:rand(6),
                         category_id:category_size.category_id,
                         trading_status:rand(4),
-                        size_id:category_size.size_id,
+                        size_id:Size.find(category_size.size_id).children.first.id,
                         brand_id:Brand.where( 'id >= ?', rand( Brand.first.id..Brand.last.id) ).first.id,
                         seller_id:User.where( 'id >= ?', rand( User.find(1).id..User.find(2).id) ).first.id,
     )

--- a/db/seeds/item.rb
+++ b/db/seeds/item.rb
@@ -3,14 +3,32 @@
   @category_sizes.each.with_index(1) do |category_size,n|
     @item=Item.create!(name:"商品#{m}-#{n}_のカテゴリは"+Category.find(category_size.category_id).name,
                         text:Size.find(category_size.size_id).kind+"からサイズを選んでます",
-                        price:300,
-                        condition:0,
+                        price:rand(300..20000),
+                        condition:rand(6),
                         category_id:category_size.category_id,
-                        trading_status:0,
+                        trading_status:rand(4),
                         size_id:category_size.size_id,
-                        brand_id:Brand.where( 'id >= ?', rand(Brand.first.id..Brand.last.id) ).first.id,
-                        seller_id:1)
+                        brand_id:Brand.where( 'id >= ?', rand( Brand.first.id..Brand.last.id) ).first.id,
+                        seller_id:User.where( 'id >= ?', rand( User.find(1).id..User.find(2).id) ).first.id,
+    )
+    if @item.read_attribute_before_type_cast(:trading_status) > 1
+      @item.update(
+        buyer_id:User.where.not(id:@item.seller_id).where( 'id >= ?', rand( User.first.id..User.last.id) ).first.id
+      )
+      Purchase.create!(item_id:@item.id,
+        seller_id:@item.seller_id,
+        buyer_id:@item.buyer_id
+      )
+    end
+
     ItemImage.create!(item_id: @item.id,
-                      image_url: open("#{Rails.root}/db/fixtures/sample.jpeg"))
+                      image_url: open("#{Rails.root}/db/fixtures/sample.jpeg")
+    )
+    Shipping.create!(item_id: @item.id,
+                      fee_burden:rand(2),
+                      service: rand(9),
+                      area: rand(1..47),
+                      handling_time: rand(3)
+    )
   end
 end

--- a/db/seeds/item.rb
+++ b/db/seeds/item.rb
@@ -1,5 +1,4 @@
 @category_sizes=CategorySize.all
-# @size=Size.where(ancestry: nil).chi
 (1..5).each do |m|
   @category_sizes.each.with_index(1) do |category_size,n|
     @item=Item.create!(name:"商品#{m}-#{n}_のカテゴリは"+Category.find(category_size.category_id).name,


### PR DESCRIPTION
# WHAT
- 商品一覧にレディース・メンズのItem反映
- 商品詳細にカテゴリーなどのItemに定義されたカラムの表記反映
- 削除画面のCSSの崩れ修正
- seed.rbの修正 
- headerからログアウトボタンの削除
- ログイン時にテストユーザーのアドレスとパスワードをデフォルト表示
- マイページの出品した商品にページネーション追加（本物とはレイアウトが少し違います）
# WHY 
明日のスプリントレビューで正常に表示されるように

# GIF&画面
- 商品一覧にレディース・メンズのItem反映
[![Image from Gyazo](https://i.gyazo.com/7c58fe5df7c7a3a0663fb88734fc190d.png)](https://gyazo.com/7c58fe5df7c7a3a0663fb88734fc190d)

- 商品詳細にカテゴリーなどのItemに定義されたカラムの表記反映
[![Image from Gyazo](https://i.gyazo.com/a100bf79e9f0d2d6d51faf1c7b0f3dcb.png)](https://gyazo.com/a100bf79e9f0d2d6d51faf1c7b0f3dcb)

- 削除画面のCSSの崩れ修正
[![Image from Gyazo](https://i.gyazo.com/8b9df08d028fb40a8b149c44ffa49074.gif)](https://gyazo.com/8b9df08d028fb40a8b149c44ffa49074)
- seed.rbの修正 

Itemにshippingテーブルのレコードとpurchaseテーブルのレコードが保存されるようにした
[![Image from Gyazo](https://i.gyazo.com/e26938cf4754ef92deeb658ce09743fd.png)](https://gyazo.com/e26938cf4754ef92deeb658ce09743fd)

- headerからログアウトボタンの削除
[![Image from Gyazo](https://i.gyazo.com/8c8e49cef0525707c352e6fca7176ef1.png)](https://gyazo.com/8c8e49cef0525707c352e6fca7176ef1)

- ログイン時にテストユーザーのアドレスとパスワードをデフォルト表示
[![Image from Gyazo](https://i.gyazo.com/396250d7cea3a857dab141cc1b13789b.png)](https://gyazo.com/396250d7cea3a857dab141cc1b13789b)

- マイページの出品した商品にページネーション追加（本物とはレイアウトが少し違います）
[![Image from Gyazo](https://i.gyazo.com/cde2c1b30680637ee7c13e393524785a.gif)](https://gyazo.com/cde2c1b30680637ee7c13e393524785a)
