### PR TITLE
商品検索Lv2のリファクタリング

### DIFF
--- a/app/assets/stylesheets/modules/item/search.scss
+++ b/app/assets/stylesheets/modules/item/search.scss
@@ -1,4 +1,4 @@
-.ransack-select {
+.ransack-select {// カテゴリー選択した際にjsにて出現する子・孫カテゴリー部分
   margin-top: 5px;
   width: 95%;
   height: 50px;
@@ -24,9 +24,7 @@
   position: relative;
   margin: 40px auto 0;
   width: 1020px;
-  display: flex;
   &__right {
-    float: right;
     width: 700px;
     height: auto;
   }
@@ -156,6 +154,19 @@
   width: 340px;
   position: relative;
   display: flex;
+  #q_sorts {
+    background: #fff;
+    height: 80px;
+    width: 340px;
+    padding: 0 16px;
+    border: 1px solid #ccc;
+    border-radius: 0.1px;
+    cursor: pointer;
+    outline: 0;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
   &__icon.fas.fa-exchange-alt {
     position: absolute;
     right: 165px;
@@ -190,7 +201,8 @@
   }
   &__search-box {
     background: #fff;
-    outline: 1px solid #ccc;
+    border: 1px solid #ccc;
+    border-left: none;
     width: 320px;
     font-size: 14px;
     height: 60px;
@@ -201,7 +213,7 @@
   display: none;
   background: #fff;
   width: 552px;
-  height: 100%;
+  height: auto;
   padding: 64px;
   box-shadow: 0 0 4px 0 rgba(0,0,0,0.4);
 }
@@ -265,6 +277,21 @@
   margin: 0 20px 0;
   width: 100%;
   height: 50%;
+}
+#q_condition_eq_any, #q_trading_status_eq_any,#q_shipping_fee_burden_eq_any {
+  margin: 8px 0 0;
+  height: 48px;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+  line-height: 1.5;
+  cursor: pointer;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 @media screen and (min-width: 1068px) {
@@ -334,7 +361,6 @@
     height: 48px;
     width: 215px;
     padding: 0 16px;
-    border-radius: 4px;
     border: 1px solid #ccc;
     background: 0;
     font-size: 16px;

--- a/app/views/items/partial/_responsive.html.haml
+++ b/app/views/items/partial/_responsive.html.haml
@@ -1,17 +1,12 @@
-.hidden-large-box
-  .hidden-select-box
-    %i.hidden-select-box__icon.fas.fa-exchange-alt
-    .hidden-select-box__name 並び替え
-    %select.hidden-select-box__left-search
-      %option{value: ""}
-      %option{value: ""}
-        これはハリボテです
-  .hidden-select-box
-    %i.hidden-select-box__icon.fas.fa-search
-    .hidden-select-box__name 詳細検索
-    %button.hidden-select-box__search-box
-%section.items-box-container
-  = search_form_for @q, url:search_items_path do |f|
+= search_form_for @q, url:search_items_path do |f|
+  .hidden-large-box
+    .hidden-select-box
+      = f.select(:sorts, { '並び替え': 'id desc', '価格の安い順': 'price asc', '価格の高い順': 'price desc', '出品の古い順': 'updated_at asc', '出品の新しい順': 'updated_at desc' }, { selected: params[:q][:sorts] }, { onchange: 'this.form.submit()'} )
+    .hidden-select-box
+      %i.hidden-select-box__icon.fas.fa-search
+      .hidden-select-box__name 詳細検索
+      .hidden-select-box__search-box
+  .items-box-container
     .search-form-group-top
       %lavel
         %i.fas.fa-plus
@@ -23,12 +18,11 @@
         %i.fas.fa-list-ul
         %span
           カテゴリーを選択する
-        .search-select-wrap{"data-search": "parent"}
+        .search-select-wrap
           .search-select-wrap__icon.fas.fa-chevron-down
-          = f.fields_for :category do |category|
-            = category.collection_select :category_id_eq, @categories, :id, :name, {prompt: "全て"}, {class: "search-input-default select"}
-        -# Jsで実装する部分%div{"data-search" => "child"}
-        -# Jsで実装する部分%div{"data-search" => "grand-child"}
+          = f.collection_select :category_id_eq, @categories, :id, :name, {prompt: "まだ実装できていない"}, class: "search-input-default select", id: "ransack_category_id"
+        #category_children
+        #category_grandchildren
     .search-form-group
       %lavel
         %i.fas.fa-tags
@@ -67,33 +61,33 @@
           %option{value: "six"}
             50000~
       .search-select-wrap.half
-        = f.number_field:price_gteq, placeholder: "¥Min", class:"search-input-default price", id: "min-price"
+        = f.search_field:price_gteq, placeholder: "¥Min", class:"search-input-default price", id: "min-price"
         %span ~
-        = f.number_field:price_lteq, placeholder: "¥Max", class:"search-input-default price", id: "max-price"
+        = f.search_field:price_lteq, placeholder: "¥Max", class:"search-input-default price", id: "max-price"
     .search-form-group.clearfix
       %lavel
-        %i.fas.fa-star
-        %span
-          商品の状態
-      %div.form-group__check
-        .checkbox
-          .checkbox__lavel
-            -# enum部分これから実装します
-            -# =f.collection_check_boxes :condition_id_in, Item.conditions.map { |k, v| [Item.conditions_I18n[k], v]}
-            -#   = b.label do
-            -#     .box
-            -#       = b.check_box
-            -#       = b.text
+      %i.fas.fa-star
+      %span
+        商品の状態
+      .search-select-wrap
+        .search-select-wrap__icon.fas.fa-chevron-down
+        = f.select :condition_eq_any, Item.conditions.map{|k,v| [Item.conditions_i18n[k], v]},{ include_blank: '全て' }
     .search-form-group
       %label
-        %i.fas.fa-truck-moving
-        %span
-          配送料の負担
+      %i.fas.fa-truck-moving
+      %span
+        配送料の負担
+      .search-select-wrap
+        .search-select-wrap__icon.fas.fa-chevron-down
+        = f.select :shipping_fee_burden_eq_any, Shipping.fee_burdens.map{|k,v| [Shipping.fee_burdens_i18n[k], v]},{ include_blank: '全て' }
     .search-form-group
       %label
-        %i.fas.fa-shopping-cart
-        %span
-          販売状況
+      %i.fas.fa-shopping-cart
+      %span
+        販売状況
+      .search-select-wrap
+        .search-select-wrap__icon.fas.fa-chevron-down
+        = f.select :trading_status_eq_any, Item.trading_statuses.map{|k,v| [Item.trading_statuses_i18n[k], v]},{ include_blank: '全て' }
     .search-extend-btn
       = f.button "クリア", type: :reset, class:"btn-default btn-gray search-btn"
       = f.submit "完了", class: "btn-default btn-red search-btn"

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -4,20 +4,20 @@
     = render 'items/partial/search'
   .search-content
     = render 'items/partial/responsive'
-    .search-container__right
-      %h2.search-result
-        = @q.name_cont
-        %span.search-result__sub の検索結果
+  .search-container__right
+    %h2.search-result
+      = @q.name_cont
+      %span.search-result__sub の検索結果
+    - if @search_result.present?
+      .search-result__num
+        = "1-#{@search_result.length}件表示"
+    - else
+      %p.search-result__description 該当する商品が見つかりません。検索条件を変えて、再度お試しください。
+      %h3.search-result__new
+        新着商品
+    .search-items
       - if @search_result.present?
-        .search-result__num
-          = "1-#{@search_result.length}件表示"
+        = render partial: 'items/partial/search-item_box', collection: @search_result, as:'item'
       - else
-        %p.search-result__description 該当する商品が見つかりません。検索条件を変えて、再度お試しください。
-        %h3.search-result__new
-          新着商品
-      .search-items
-        - if @search_result.present?
-          = render partial: 'items/partial/search-item_box', collection: @search_result, as:'item'
-        - else
-          = render partial: 'items/partial/search-item_box', collection: @new_items, as:'item'
+        = render partial: 'items/partial/search-item_box', collection: @new_items, as:'item'
 = render 'layouts/footer'


### PR DESCRIPTION
## WHAT

- 画面サイズが1068px以下にした際の商品検索Lv2部分の実装
- ソート検索・商品状態・配送料の負担・販売状況部分の検索ができるように

## WHY

- レスポンシブ対応のデバイスフレンドリーな実装にする事でユーザビリティを向上させる為

## IMAGE

- 商品状態・配送料の負担・販売状況部分の検索
![demo](https://gyazo.com/50bdd9650f9b9bfa235b4852bf629c15/raw)
- ソート検索
![demo](https://gyazo.com/2acbc4b136a558116f865112a6edf5db/raw)

## 備考

- カテゴリー検索のJs発火がうまくいかないのでカテゴリー検索部分はこの後実装します
- 画面サイズ1068px以上の場合の商品検索Lv2は実装済み